### PR TITLE
Updated ReadMe for Windows 10 devices and fixed 1920x1200 resolution implementation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ behavior.
 
 * `-locale` Get the Bing image of the day for this area.
 
-  **Possible values** `'de-DE'`, `'en-AU'`, `'en-CA'`, `'en-NZ'`,
-  `'en-UK'`, `'en-US'`, `'ja-JP'`, `'zh-CN'`
+  **Possible values** `de-DE`, `en-AU`, `en-CA`, `en-NZ`,
+  `en-UK`, `en-US`, `ja-JP`, `zh-CN`
 
-  **Default value** `'en-US'`
+  **Default value** `en-US`
 
 * `-files` Keep only this number of images in the folder, *any other
   file matching* `????-??-??.jpg` *will be* **removed**!
@@ -34,13 +34,13 @@ behavior.
   not remove any file.
 
 * `-resolution` Determines which image resolution will be downloaded.
-  If set to `'auto'` the script will try to determine which resolution
-  is more appropriate based on your primary screen resolution.
+  If set to `auto` the script will try to determine which resolution
+  is more appropriate based on your primary screen resolution (Note: this does not work in Windows 10).
 
-  **Possible values** `'auto'`, `'1024x768'`, `'1280x720'`,
-  `'1366x768'`, `'1920x1080'`, `'1920x1200'`
+  **Possible values** `auto`, `1024x768`, `1280x720`,
+  `1366x768`, `1920x1080`, `1920x1200`
 
-  **Default value** `'auto'`
+  **Default value** `auto`
 
 * `-downloadFolder` Destination folder to download the wallpapers to.
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ install).
 
 Script options
 --------------
-The script supports several option which allows you to customize its
+The script supports several options which allows you to customize the
 behavior.
 
 * `-locale` Get the Bing image of the day for this area.
@@ -35,12 +35,13 @@ behavior.
 
 * `-resolution` Determines which image resolution will be downloaded.
   If set to `auto` the script will try to determine which resolution
-  is more appropriate based on your primary screen resolution (Note: this does not work in Windows 10).
+  is more appropriate based on your primary screen resolution.
+  **(Note: the auto option does not work in Windows 10)**
 
   **Possible values** `auto`, `1024x768`, `1280x720`,
   `1366x768`, `1920x1080`, `1920x1200`
 
-  **Default value** `auto`
+  **Default value** `auto` (needs to be set manually for windows 10 devices)
 
 * `-downloadFolder` Destination folder to download the wallpapers to.
 

--- a/bing-wallpapers.ps1
+++ b/bing-wallpapers.ps1
@@ -12,7 +12,7 @@ Param(
     [int]$files = 3,
 
     # Resolution of the image to download
-    [ValidateSet('auto', '1024x768', '1280x720', '1366x768', '1920x1080')][string]$resolution = 'auto',
+    [ValidateSet('auto', '1024x768', '1280x720', '1366x768', '1920x1080', '1920x1200')][string]$resolution = 'auto',
 
     # Destination folder to download the wallpapers to
     [string]$downloadFolder = "$([Environment]::GetFolderPath("MyPictures"))\Wallpapers"
@@ -24,6 +24,7 @@ Param(
 [string]$uri = "$hostname/HPImageArchive.aspx?format=xml&idx=0&n=$maxItemCount&mkt=$locale"
 
 # Get the appropiate screen resolution
+# (Doesn't work in Windows 10 for some reason)
 if ($resolution -eq 'auto') {
     Add-Type -AssemblyName System.Windows.Forms
     $primaryScreen = [System.Windows.Forms.Screen]::AllScreens | Where-Object {$_.Primary -eq 'True'}


### PR DESCRIPTION
I added in a warning for windows 10 users that the auto resolution feature doesn't work properly. Also added 1920x1200 to the valid inputs list so it can be used.