### PR TITLE
Support non-Windows systems, don't delete files by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 Bing image of the day
 =====================
+
+This is a fork of https://github.com/timothymctim/Bing-wallpapers
+
+## Added Features
+1. Can use an alternate (unofficial) source of image metadata: `-useJsonSource`
+1. Adding a script (`update-imagemetadata.ps1`) that uses  [ExifTool](https://exiftool.org/) to update the image metadata in the source files to reflect the metadata in the feed. The images don't include them, strangely. Note that ExifTool is available for MacOS and Windows, but not Linux.
+
+---
+
 This Windows PowerShell script automatically fetches the Bing image of
 the day.
 Using this script you can set the Bing image of the day as your

--- a/bing-wallpapers.ps1
+++ b/bing-wallpapers.ps1
@@ -143,7 +143,7 @@ if ($files -gt 0) {
 }
 
 $items = $items | Sort-Object -Property date -Unique
-Write-Verbose "Downloading images..."
+Write-Verbose "Downloading $($items.length) images..."
 $client = New-Object System.Net.WebClient
 foreach ($item in $items) {
     $baseName = $item.date.ToString("yyyy-MM-dd")
@@ -153,7 +153,9 @@ foreach ($item in $items) {
 
     # Download the enclosure if we haven't done so already
     if (!(Test-Path $destination) -and !(Test-Path $destinationMetadata)) {
-        Write-Host "Downloading image to $destination"
+        Write-Verbose "Test-Path $destination $(Test-Path $destination)"
+        Write-Verbose "Test-Path $destinationMetadata $(Test-Path $destinationMetadata)"
+        Write-Verbose "Downloading image to $destination"
         $client.DownloadFile($url, "$destination")
     }
 }

--- a/bing-wallpapers.ps1
+++ b/bing-wallpapers.ps1
@@ -143,16 +143,17 @@ if ($files -gt 0) {
 }
 
 $items = $items | Sort-Object -Property date -Unique
-Write-Host "Downloading images..."
+Write-Verbose "Downloading images..."
 $client = New-Object System.Net.WebClient
 foreach ($item in $items) {
     $baseName = $item.date.ToString("yyyy-MM-dd")
     $destination = Join-Path $downloadFolder "$baseName.jpg"
+    $destinationMetadata = Join-Path $downloadFolder $($baseName + "_meta.jpg")
     $url = $item.url
 
     # Download the enclosure if we haven't done so already
-    if (!(Test-Path $destination)) {
-        Write-Verbose "Downloading image to $destination"
+    if (!(Test-Path $destination) -and !(Test-Path $destinationMetadata)) {
+        Write-Host "Downloading image to $destination"
         $client.DownloadFile($url, "$destination")
     }
 }
@@ -161,7 +162,7 @@ if ($removeExistingFiles -and ($files -gt 0)) {
     # We do not want to keep every file; remove the old ones
     Write-Host "Cleaning the directory..."
     $i = 1
-    Get-ChildItem -Filter "????-??-??.jpg" $downloadFolder | Sort-Object -Descending FullName | ForEach-Object {
+    Get-ChildItem -Filter "*.jpg" "$downloadFolder\*" -Include "????-??-??.jpg","????-??-??_meta.jpg" | Sort-Object -Descending FullName | ForEach-Object {
         if ($i -gt $files) {
             # We have more files than we want, delete the extra files
             $fileName = $_.FullName

--- a/bing-wallpapers.ps1
+++ b/bing-wallpapers.ps1
@@ -100,7 +100,7 @@ $pageSize = 8
 $items = New-Object System.Collections.ArrayList
 if ($files -gt 0) {
     if ($useJsonSource) {
-        $jsonImgs = ConvertFrom-Json -InputObject $(Invoke-WebRequest -Uri 'https://api45gabs.azurewebsites.net/api/sample/bingphotos')
+        $jsonImgs = ConvertFrom-Json -InputObject $(Invoke-WebRequest -UseBasicParsing -Uri 'https://api45gabs.azurewebsites.net/api/sample/bingphotos').Content
         for ($i = 0; $i -lt $files; $i++) {
             [datetime]$imageDate = [datetime]::ParseExact($jsonImgs[$i].startdate, 'yyyyMMdd', $null)
             [string]$imageUrl = "$hostname$($jsonImgs[$i].urlBase)_$resolution.jpg"
@@ -152,7 +152,7 @@ foreach ($item in $items) {
 
     # Download the enclosure if we haven't done so already
     if (!(Test-Path $destination)) {
-        Write-Debug "Downloading image to $destination"
+        Write-Verbose "Downloading image to $destination"
         $client.DownloadFile($url, "$destination")
     }
 }

--- a/bing-wallpapers.ps1
+++ b/bing-wallpapers.ps1
@@ -49,19 +49,19 @@ else {
 # Get the appropiate screen resolution
 if ($resolution -eq 'auto') {
     if ($PSVersionTable.OS.Contains('Windows')) {
-        $os = 'Windows'
+        Write-Verbose 'On Windows'
         Add-Type -AssemblyName System.Windows.Forms
         $primaryScreen = [System.Windows.Forms.Screen]::AllScreens | Where-Object { $_.Primary -eq 'True' }
         $width = $primaryScreen.Bounds.Width
         $height = $primaryScreen.Bounds.Height
     }
     elseif ($PSVersionTable.OS.Contains('Darwin')) {
-        $os = 'MacOS'
-        system_profiler SPDisplaysDataType -json | ConvertFrom-Json -OutVariable $displayInfo
+        Write-Verbose 'On MacOS'
+        $null = system_profiler SPDisplaysDataType -json | ConvertFrom-Json -OutVariable displayInfo
         foreach ($item in $displayInfo) {
             if ($item[0].SPDisplaysDataType[0].spdisplays_ndrvs.spdisplays_main -eq 'spdisplays_yes') {
-                $width = $item[0].SPDisplaysDataType[0].spdisplays_ndrvs.spdisplays_resolution.split("@")[0].split('x')[0].Trim()
-                $height = $item[0].SPDisplaysDataType[0].spdisplays_ndrvs.spdisplays_resolution.split("@")[0].split('x')[1].Trim()
+                [int]$width = $item[0].SPDisplaysDataType[0].spdisplays_ndrvs.spdisplays_resolution.split("@")[0].split('x')[0].Trim()
+                [int]$height = $item[0].SPDisplaysDataType[0].spdisplays_ndrvs.spdisplays_resolution.split("@")[0].split('x')[1].Trim()
             }
         }
     }

--- a/bing-wallpapers.ps1
+++ b/bing-wallpapers.ps1
@@ -7,51 +7,65 @@
 Param(
     # Get the Bing image of this country
     [ValidateSet('auto', 'ar-XA', 'bg-BG', 'cs-CZ', 'da-DK', 'de-AT',
-    'de-CH', 'de-DE', 'el-GR', 'en-AU', 'en-CA', 'en-GB', 'en-ID',
-    'en-IE', 'en-IN', 'en-MY', 'en-NZ', 'en-PH', 'en-SG', 'en-US',
-    'en-XA', 'en-ZA', 'es-AR', 'es-CL', 'es-ES', 'es-MX', 'es-US',
-    'es-XL', 'et-EE', 'fi-FI', 'fr-BE', 'fr-CA', 'fr-CH', 'fr-FR',
-    'he-IL', 'hr-HR', 'hu-HU', 'it-IT', 'ja-JP', 'ko-KR', 'lt-LT',
-    'lv-LV', 'nb-NO', 'nl-BE', 'nl-NL', 'pl-PL', 'pt-BR', 'pt-PT',
-    'ro-RO', 'ru-RU', 'sk-SK', 'sl-SL', 'sv-SE', 'th-TH', 'tr-TR',
-    'uk-UA', 'zh-CN', 'zh-HK', 'zh-TW')][string]$locale = 'auto',
+        'de-CH', 'de-DE', 'el-GR', 'en-AU', 'en-CA', 'en-GB', 'en-ID',
+        'en-IE', 'en-IN', 'en-MY', 'en-NZ', 'en-PH', 'en-SG', 'en-US',
+        'en-XA', 'en-ZA', 'es-AR', 'es-CL', 'es-ES', 'es-MX', 'es-US',
+        'es-XL', 'et-EE', 'fi-FI', 'fr-BE', 'fr-CA', 'fr-CH', 'fr-FR',
+        'he-IL', 'hr-HR', 'hu-HU', 'it-IT', 'ja-JP', 'ko-KR', 'lt-LT',
+        'lv-LV', 'nb-NO', 'nl-BE', 'nl-NL', 'pl-PL', 'pt-BR', 'pt-PT',
+        'ro-RO', 'ru-RU', 'sk-SK', 'sl-SL', 'sv-SE', 'th-TH', 'tr-TR',
+        'uk-UA', 'zh-CN', 'zh-HK', 'zh-TW')][string]$locale = 'auto',
 
-    # Download the latest $files wallpapers
+    # Download the latest $files wallpapers.
+    [ValidateRange(0, 15)]
     [int]$files = 3,
+
+    # Keep existing files
+    [switch]$removeExistingFiles,
 
     # Resolution of the image to download
     [ValidateSet('auto', '800x600', '1024x768', '1280x720', '1280x768',
-    '1366x768', '1920x1080', '1920x1200', '720x1280', '768x1024',
-    '768x1280', '768x1366', '1080x1920')][string]$resolution = 'auto',
+        '1366x768', '1920x1080', '1920x1200', '720x1280', '768x1024',
+        '768x1280', '768x1366', '1080x1920')][string]$resolution = 'auto',
 
     # Destination folder to download the wallpapers to
-    [string]$downloadFolder = "$([Environment]::GetFolderPath("MyPictures"))\Wallpapers"
+    [string]$downloadFolder = $(Join-Path $([Environment]::GetFolderPath("MyPictures")) "Wallpapers")
 )
 # Max item count: the number of images we'll query for
-[int]$maxItemCount = [System.Math]::max(1, [System.Math]::max($files, 8))
+# [int]$maxItemCount = [System.Math]::max(1, [System.Math]::max($files, 8))
 # URI to fetch the image locations from
 if ($locale -eq 'auto') {
     $market = ""
-} else {
+}
+else {
     $market = "&mkt=$locale"
 }
 [string]$hostname = "https://www.bing.com"
-[string]$uri = "$hostname/HPImageArchive.aspx?format=xml&idx=0&n=$maxItemCount$market"
+[string]$uri = "$hostname/HPImageArchive.aspx?format=xml$market&pid=hp"
 
 # Get the appropiate screen resolution
 if ($resolution -eq 'auto') {
-    Add-Type -AssemblyName System.Windows.Forms
-    $primaryScreen = [System.Windows.Forms.Screen]::AllScreens | Where-Object {$_.Primary -eq 'True'}
-    if ($primaryScreen.Bounds.Width -le 1024) {
-        $resolution = '1024x768'
-    } elseif ($primaryScreen.Bounds.Width -le 1280) {
-        $resolution = '1280x720'
-    } elseif ($primaryScreen.Bounds.Width -le 1366) {
-        $resolution = '1366x768'
-    } elseif ($primaryScreen.Bounds.Height -le 1080) {
+    if ($PSVersionTable.OS.Contains('Windows')) {
+        Add-Type -AssemblyName System.Windows.Forms
+        $primaryScreen = [System.Windows.Forms.Screen]::AllScreens | Where-Object { $_.Primary -eq 'True' }
+        if ($primaryScreen.Bounds.Width -le 1024) {
+            $resolution = '1024x768'
+        }
+        elseif ($primaryScreen.Bounds.Width -le 1280) {
+            $resolution = '1280x720'
+        }
+        elseif ($primaryScreen.Bounds.Width -le 1366) {
+            $resolution = '1366x768'
+        }
+        elseif ($primaryScreen.Bounds.Height -le 1080) {
+            $resolution = '1920x1080'
+        }
+        else {
+            $resolution = '1920x1200'
+        }
+    }
+    else {
         $resolution = '1920x1080'
-    } else {
-        $resolution = '1920x1200'
     }
 }
 
@@ -60,36 +74,43 @@ if (!(Test-Path $downloadFolder)) {
     New-Item -ItemType Directory $downloadFolder
 }
 
-$request = Invoke-WebRequest -Uri $uri
-[xml]$content = $request.Content
-
+# Add paging support for when number requested > 8
+# &idx=0&n=$maxItemCount
+$pageSize = 8
 $items = New-Object System.Collections.ArrayList
-foreach ($xmlImage in $content.images.image) {
-    [datetime]$imageDate = [datetime]::ParseExact($xmlImage.startdate, 'yyyyMMdd', $null)
-    [string]$imageUrl = "$hostname$($xmlImage.urlBase)_$resolution.jpg"
-
-    # Add item to our array list
-    $item = New-Object System.Object
-    $item | Add-Member -Type NoteProperty -Name date -Value $imageDate
-    $item | Add-Member -Type NoteProperty -Name url -Value $imageUrl
-    $null = $items.Add($item)
-}
-
-# Keep only the most recent $files items to download
-if (!($files -eq 0) -and ($items.Count -gt $files)) {
-    # We have too many matches, keep only the most recent
-    $items = $items|Sort date
-    while ($items.Count -gt $files) {
-        # Pop the oldest item of the array
-        $null, $items = $items
+if ($files -gt 0) {
+    $pageAndRemainder = [System.Math]::DivRem($files, $pageSize)
+    # To support remainder logic vs 0 offset pages
+    if (($pageAndRemainder.item2 -eq 0) -and ($pagesAndRemainder.item1 -ne 0)) {
+        $pages = $pageAndRemainder.Item1 - 1
+    }
+    else {
+        $pages = $pageAndRemainder.item1
+    }
+    for ($i = 0; $i -le $pages; $i++) {
+        if ($pages -eq $i) { $pageItems = $pageAndRemainder.Item2 } else { $pageItems = $pageSize }
+        [string]$pageUri = $uri + "&idx=$($i * $pageSize)&n=$pageItems"
+        $request = Invoke-WebRequest -Uri $pageUri -DisableKeepAlive -UserAgent 'parp-1.0'
+        [xml]$content = $request.Content
+        
+        foreach ($xmlImage in $content.images.image) {
+            [datetime]$imageDate = [datetime]::ParseExact($xmlImage.startdate, 'yyyyMMdd', $null)
+            [string]$imageUrl = "$hostname$($xmlImage.urlBase)_$resolution.jpg"
+        
+            # Add item to our array list
+            $item = New-Object System.Object
+            $item | Add-Member -Type NoteProperty -Name date -Value $imageDate
+            $item | Add-Member -Type NoteProperty -Name url -Value $imageUrl
+            $null = $items.Add($item)
+        }
     }
 }
-
+$items = $items | Sort-Object -Property date -Unique
 Write-Host "Downloading images..."
 $client = New-Object System.Net.WebClient
 foreach ($item in $items) {
     $baseName = $item.date.ToString("yyyy-MM-dd")
-    $destination = "$downloadFolder\$baseName.jpg"
+    $destination = Join-Path $downloadFolder "$baseName.jpg"
     $url = $item.url
 
     # Download the enclosure if we haven't done so already
@@ -99,11 +120,11 @@ foreach ($item in $items) {
     }
 }
 
-if ($files -gt 0) {
+if ($removeExistingFiles -and ($files -gt 0)) {
     # We do not want to keep every file; remove the old ones
     Write-Host "Cleaning the directory..."
     $i = 1
-    Get-ChildItem -Filter "????-??-??.jpg" $downloadFolder | Sort -Descending FullName | ForEach-Object {
+    Get-ChildItem -Filter "????-??-??.jpg" $downloadFolder | Sort-Object -Descending FullName | ForEach-Object {
         if ($i -gt $files) {
             # We have more files than we want, delete the extra files
             $fileName = $_.FullName

--- a/bing-wallpapers.ps1
+++ b/bing-wallpapers.ps1
@@ -49,26 +49,43 @@ else {
 # Get the appropiate screen resolution
 if ($resolution -eq 'auto') {
     if ($PSVersionTable.OS.Contains('Windows')) {
+        $os = 'Windows'
         Add-Type -AssemblyName System.Windows.Forms
         $primaryScreen = [System.Windows.Forms.Screen]::AllScreens | Where-Object { $_.Primary -eq 'True' }
-        if ($primaryScreen.Bounds.Width -le 1024) {
-            $resolution = '1024x768'
-        }
-        elseif ($primaryScreen.Bounds.Width -le 1280) {
-            $resolution = '1280x720'
-        }
-        elseif ($primaryScreen.Bounds.Width -le 1366) {
-            $resolution = '1366x768'
-        }
-        elseif ($primaryScreen.Bounds.Height -le 1080) {
-            $resolution = '1920x1080'
-        }
-        else {
-            $resolution = '1920x1200'
+        $width = $primaryScreen.Bounds.Width
+        $height = $primaryScreen.Bounds.Height
+    }
+    elseif ($PSVersionTable.OS.Contains('Darwin')) {
+        $os = 'MacOS'
+        system_profiler SPDisplaysDataType -json | ConvertFrom-Json -OutVariable $displayInfo
+        foreach ($item in $displayInfo) {
+            if ($item[0].SPDisplaysDataType[0].spdisplays_ndrvs.spdisplays_main -eq 'spdisplays_yes') {
+                $width = $item[0].SPDisplaysDataType[0].spdisplays_ndrvs.spdisplays_resolution.split("@")[0].split('x')[0].Trim()
+                $height = $item[0].SPDisplaysDataType[0].spdisplays_ndrvs.spdisplays_resolution.split("@")[0].split('x')[1].Trim()
+            }
         }
     }
     else {
+        # Default for Linux
+        $width = 1920
+        $height = 1080
+    }
+
+    # Determine the resolution to download based on width and height
+    if ($width -le 1024) {
+        $resolution = '1024x768'
+    }
+    elseif ($width -le 1280) {
+        $resolution = '1280x720'
+    }
+    elseif ($width -le 1366) {
+        $resolution = '1366x768'
+    }
+    elseif ($height -le 1080) {
         $resolution = '1920x1080'
+    }
+    else {
+        $resolution = '1920x1200'
     }
 }
 

--- a/update-imagedata.ps1
+++ b/update-imagedata.ps1
@@ -1,7 +1,14 @@
 # Insert image data into the files EXIF using EXIFTOOL
 [string]$downloadFolder = $(Join-Path $([Environment]::GetFolderPath("MyPictures")) "Wallpapers")
+$fileCount = $(Get-ChildItem -Filter "*.jpg" "$downloadFolder\*" -Include "????-??-??.jpg" -Exclude "????-??-??_meta.jpg")
+if ($null -eq $fileCount) {
+    Write-Verbose 'No files to process'
+    return
+}
+Write-Verbose "$($fileCount.Count) image(s) to process"
 $MyJsonImages = ConvertFrom-Json -InputObject $(Invoke-WebRequest -UseBasicParsing -Uri 'https://api45gabs.azurewebsites.net/api/sample/bingphotos').Content
-foreach ($file in $(Get-ChildItem -Filter "*.jpg" "$downloadFolder\*" -Include "????-??-??.jpg" -Exclude "????-??-??_meta.jpg" | Sort-Object -Descending)) {
+[xml]$MyXmlImages = ''
+foreach ($file in ($fileCount | Sort-Object -Descending)) {
     $existingCopyRight = exiftool -Copyright $($file.FullName)
     if ($null -ne $existingCopyRight) {
         Write-Verbose "$($file.FullName) already has copyright info"
@@ -10,22 +17,42 @@ foreach ($file in $(Get-ChildItem -Filter "*.jpg" "$downloadFolder\*" -Include "
     $startDate = $file.BaseName.Replace('-', '').Trim()    
     $imageMetadata = $MyJsonImages.Where{ $PSItem.startdate -eq $startDate }[0]
     if (($null -eq $imageMetadata) -or ('' -eq $imageMetadata )) {
-        Write-Verbose "No metadata available for $file"
+        # Check the XML data
+        try {
+            Write-Verbose "XML path"
+            if ($MyXmlImages.HasChildNodes = $false) {
+                $MyXmlImages = (Invoke-WebRequest -Uri "https://www.bing.com/HPImageArchive.aspx?format=xml&mkt=$PSCulture&pid=hp&idx=0&n=8").Content
+            }
+            $hash = @{"copyright" = ''; "title" = '' }
+            $imageMetadata = [pscustomobject]$hash
+            Write-Verbose "//image[startdate[text() = '$startDate']]"
+            $imageMetadata.copyright = $(Select-Xml -Xml $MyXmlImages -XPath "//image[startdate[text() = '$startDate']]").Node.SelectSingleNode('copyright').InnerText.Trim()
+            Write-Verbose "ImageMetadata.Copyright: $($imageMetadata.copyright)"
+            $imageMetadata.title = $(Select-Xml -Xml $MyXmlImages -XPath "//image[startdate[text() = '$startDate']]").Node.SelectSingleNode('headline').InnerText.Trim()
+            Write-Verbose "ImageMetadata.title: $($imageMetadata.title)"
+            if ([string]::IsNullOrEmpty($imageMetadata.title)) {
+                Write-Verbose "No metadata available for $file"
+                continue
+            }
+        }
+        catch {
+            Write-Verbose "No metadata available for $file"
+            continue
+        }
     }
-    else {  
-        Write-Verbose "Processing $($file.FullName) for copyright info"
-        Write-Verbose $($imageMetadata.copyright)
+    Write-Verbose "Processing $($file.FullName) for copyright info"
+    Write-Verbose $($imageMetadata.copyright)
         
-        $splitSourceCopyright = $imageMetadata.copyright.split('(')
-        $description = $splitSourceCopyright[0].trim()
-        $copyright = $splitSourceCopyright[1].substring(0, $splitSourceCopyright[1].length - 2)
-        $title = $imageMetadata.title
+    $splitSourceCopyright = $imageMetadata.copyright.split('(')
+    $description = $splitSourceCopyright[0].trim()
+    $copyright = $splitSourceCopyright[1].substring(0, $splitSourceCopyright[1].length - 2)
+    $title = $imageMetadata.title
         
-        Write-Verbose $description
-        Write-Verbose $copyright
-        Write-Verbose "Updating $($file.FullName)"
+    Write-Verbose $description
+    Write-Verbose $copyright
+    Write-Verbose "Updating $($file.FullName)"
         
-        exiftool -overwrite_original -Title="$title" -Description="$description" -Copyright="$copyright" -CreatorWorkURL="$($imageMetadata.copyrightlink)" $($file.FullName)
-        Rename-Item -Path $file.FullName $($file.BaseName + "_meta" + $file.Extension)
-    }
+    $null = exiftool -overwrite_original -Title="$title" -Description="$description" -Copyright="$copyright" -CreatorWorkURL="$($imageMetadata.copyrightlink)" $($file.FullName)
+    Rename-Item -Path $file.FullName $($file.BaseName + "_meta" + $file.Extension)
+    
 }

--- a/update-imagedata.ps1
+++ b/update-imagedata.ps1
@@ -1,0 +1,29 @@
+# Insert image data into the files EXIF using EXIFTOOL
+[string]$downloadFolder = $(Join-Path $([Environment]::GetFolderPath("MyPictures")) "Wallpapers")
+$MyJsonImages = ConvertFrom-Json -InputObject $(Invoke-WebRequest -UseBasicParsing -Uri 'https://api45gabs.azurewebsites.net/api/sample/bingphotos').Content
+foreach ($file in $(Get-ChildItem -Path $downloadFolder -File -Filter '*.jpg' | Sort-Object -Descending)) {
+    $existingCopyRight = exiftool -Copyright $($file.FullName)
+    if ($null -ne $existingCopyRight) {
+        Write-Verbose "$($file.FullName) already has copyright info"
+        continue
+    }
+    $startDate = $file.BaseName.Replace('-', '').Trim()    
+    $imageMetadata = $MyJsonImages.Where{$PSItem.startdate -eq $startDate}[0]
+    if (($null -eq $imageMetadata) -or ('' -eq $imageMetadata )) {
+        Write-Verbose "No metadata available for $file"
+    } else {  
+        Write-Verbose "Processing $($file.FullName) for copyright info"
+        Write-Verbose $($imageMetadata.copyright)
+        
+        $splitSourceCopyright = $imageMetadata.copyright.split('(')
+        $description = $splitSourceCopyright[0].trim()
+        $copyright = $splitSourceCopyright[1].substring(0, $splitSourceCopyright[1].length - 2)
+        $title = $imageMetadata.title
+        
+        Write-Verbose $description
+        Write-Verbose $copyright
+        Write-Verbose "Updating $($file.FullName)"
+        
+        exiftool -overwrite_original -Title="$title" -Description="$description" -Copyright="$copyright" -CreatorWorkURL="$($imageMetadata.copyrightlink)" $($file.FullName)
+    }
+}

--- a/update-imagedata.ps1
+++ b/update-imagedata.ps1
@@ -1,17 +1,18 @@
 # Insert image data into the files EXIF using EXIFTOOL
 [string]$downloadFolder = $(Join-Path $([Environment]::GetFolderPath("MyPictures")) "Wallpapers")
 $MyJsonImages = ConvertFrom-Json -InputObject $(Invoke-WebRequest -UseBasicParsing -Uri 'https://api45gabs.azurewebsites.net/api/sample/bingphotos').Content
-foreach ($file in $(Get-ChildItem -Path $downloadFolder -File -Filter '*.jpg' | Sort-Object -Descending)) {
+foreach ($file in $(Get-ChildItem -Filter "*.jpg" "$downloadFolder\*" -Include "????-??-??.jpg" -Exclude "????-??-??_meta.jpg" | Sort-Object -Descending)) {
     $existingCopyRight = exiftool -Copyright $($file.FullName)
     if ($null -ne $existingCopyRight) {
         Write-Verbose "$($file.FullName) already has copyright info"
         continue
     }
     $startDate = $file.BaseName.Replace('-', '').Trim()    
-    $imageMetadata = $MyJsonImages.Where{$PSItem.startdate -eq $startDate}[0]
+    $imageMetadata = $MyJsonImages.Where{ $PSItem.startdate -eq $startDate }[0]
     if (($null -eq $imageMetadata) -or ('' -eq $imageMetadata )) {
         Write-Verbose "No metadata available for $file"
-    } else {  
+    }
+    else {  
         Write-Verbose "Processing $($file.FullName) for copyright info"
         Write-Verbose $($imageMetadata.copyright)
         
@@ -25,5 +26,6 @@ foreach ($file in $(Get-ChildItem -Path $downloadFolder -File -Filter '*.jpg' | 
         Write-Verbose "Updating $($file.FullName)"
         
         exiftool -overwrite_original -Title="$title" -Description="$description" -Copyright="$copyright" -CreatorWorkURL="$($imageMetadata.copyrightlink)" $($file.FullName)
+        Rename-Item -Path $file.FullName $($file.BaseName + "_meta" + $file.Extension)
     }
 }


### PR DESCRIPTION
Here's some changes to support 
1. MacOS and other non-Windows OSs.
2. Support for paged results up to 15 images (seems to be the limit based on the API)

Use it for parts if you wish.